### PR TITLE
Update package.json for macOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,6 +134,26 @@
       "target": "dmg",
       "icon": "build/icon.icns",
       "artifactName": "${productName} v${version}.${ext}",
+      "electronLanguages": [
+        "en",
+        "pl"
+      ],
+      "extraResources": [
+        {
+          "from": "electron-resources/extensions",
+          "to": "electron-resources/extensions",
+          "filter": [
+            "**/*"
+          ]
+        },
+        {
+          "from": "mpv",
+          "to": "mpv",
+          "filter": [
+            "**/*.lua"
+          ]
+        }
+      ],
       "fileAssociations": [
         {
           "ext": [


### PR DESCRIPTION
1. Bundles missing resources:

- `electron-resources/extensions` — Yomitan isn't present on macOS.
- `mpv/yall_auto_pause.lua` — [referenced by mpv-manager.ts:41](https://github.com/kgurniak91/yall-mp/blob/620c653e14f306202bee64cdc0265ac2fd2722e3/mpv-manager.ts#L41), but not copied into the bundle.

2. Sets `electronLanguages` for mac. Without it, Polish mixed with English within macOS menus and system dialogs (e.g., adding a video file); adding the en locale cleans that up.

Commit only affects the mac build.